### PR TITLE
Tested new woo and wp and things are still working

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Brad Davis
 Tags: woocommerce, woocommerce-price, wc-admin, woocommerce-admin, woocommerce-product-settings, admin, wp-admin, wordpress-admin
 Requires at least: 4.0
-Tested up to: 5.2.4
+Tested up to: 5.5.1
 Stable tag: 1.7.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -87,8 +87,8 @@ No, You will need to tidy this up yourself using a little CSS styling.
 == Changelog ==
 
 = 1.7.4 =
-* Tested on WordPress 5.2.4
-* Tested on WooCommerce 3.7.1
+* Tested on WordPress 5.5.1
+* Tested on WooCommerce 4.6.1
 
 = 1.7.3 =
 * Tested on WordPress 5.2.2

--- a/woocommerce-rrp.php
+++ b/woocommerce-rrp.php
@@ -11,7 +11,7 @@
  * Text Domain: woocommerce-rrp
  * Domain Path: /languages
  * WC requires at least: 3.0.0
- * WC tested up to: 3.7.1
+ * WC tested up to: 4.6.1
  *
  * @author    Bradley Davis
  * @package   WooCommerce RRP


### PR DESCRIPTION
This PR tests the following versions
- WP: 5.5.1
- WC: 4.6.1

Tested:
- WooCommerce -> Settings:
-- Product Price Text - text added
-- Sale Price Text - text added
-- Show Text On Archives - ticked