### PR TITLE
Fix no price display

### DIFF
--- a/public/partials/class-woocommerce-rrp-render-category.php
+++ b/public/partials/class-woocommerce-rrp-render-category.php
@@ -51,7 +51,7 @@ class WooCommerce_RRP_Render_Category {
 		$woo_rrp_before_sale_price = apply_filters( 'woo_rrp_before_sale_price', get_option( 'woo_rrp_before_sale_price', 1 ) ) . ' ';
 		$woo_rrp_archive_option    = get_option( 'woo_rrp_archive_option', 1 );
 
-		if ( '' !== $price ) :
+		if ( null !== $price  ) :
 
 			if ( 'yes' === $woo_rrp_archive_option && ( is_product_category() || is_shop() ) ) :
 

--- a/public/partials/class-woocommerce-rrp-render-single-product.php
+++ b/public/partials/class-woocommerce-rrp-render-single-product.php
@@ -51,7 +51,7 @@ class WooCommerce_RRP_Render_Single_Product {
 		$woo_rrp_before_sale_price = apply_filters( 'woo_rrp_before_sale_price', get_option( 'woo_rrp_before_sale_price', 1 ) ) . ' ';
 		$woo_rrp_archive_option    = get_option( 'woo_rrp_archive_option', 1 );
 
-		if ( '' !== $price ) :
+		if ( null !== $price ) :
 
 			if ( is_product() && $product->is_on_sale() ) :
 				$woo_rrp_replace = array(

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Brad Davis
 Tags: woocommerce, woocommerce-price, wc-admin, woocommerce-admin, woocommerce-product-settings, admin, wp-admin, wordpress-admin
 Requires at least: 4.0
 Tested up to: 5.5.1
-Stable tag: 1.7.4
+Stable tag: 1.7.5
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -85,6 +85,10 @@ No, You will need to tidy this up yourself using a little CSS styling.
 6. Here you can see the arrows pointing to the text entered in "Product Price Text" and "Sale Price Text" on an archive.
 
 == Changelog ==
+
+= 1.7.5 =
+* Updated single product to not output product price text field when price is empty
+* Updated category view to not output product price text field when price is empty
 
 = 1.7.4 =
 * Tested on WordPress 5.5.1

--- a/woocommerce-rrp.php
+++ b/woocommerce-rrp.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce RRP
  * Plugin URI: http://bradley-davis.com/wordpress-plugins/woocommerce-rrp/
  * Description: WooCommerce RRP allows users to add text before the regular price and sale price of a product from within WooCommerce General settings.
- * Version: 1.7.4
+ * Version: 1.7.5
  * Author: Bradley Davis
  * Author URI: http://bradley-davis.com
  * License: GPL3


### PR DESCRIPTION
## Context [Support ticket on WP Repo](https://wordpress.org/support/topic/text-does-not-disappear-when-there-is-no-price/)

Update conditional on single product and category if there is no price it is now a null value.